### PR TITLE
[FEATURE]: added planets domain :sparkles:

### DIFF
--- a/src/modules/planets/domains/Planet.spec.ts
+++ b/src/modules/planets/domains/Planet.spec.ts
@@ -1,0 +1,41 @@
+import { left } from '@shared/either';
+import { PlanetsBuild } from './builds/PlanetsBuild';
+import { InvalidPlanetDispositionException } from './exceptions/InvalidPlanetDispositionException';
+import { Planet } from './Planet';
+
+describe('[UNIT] - [Planets] - Planet Entity', () => {
+  it('should be able to create a Planet, when credentials are valid', () => {
+    const data = PlanetsBuild.generate();
+    const planetOrError = Planet.create(data);
+
+    expect(planetOrError.isLeft()).toBeFalsy();
+    expect(planetOrError.value).toBeInstanceOf(Planet);
+
+    const planet = planetOrError.value as Planet;
+
+    expect(planet.id).toBeDefined();
+    expect(planet.props).toEqual(
+      expect.objectContaining({
+        ...data,
+        disposition: {
+          props: {
+            value: data.disposition,
+          },
+        },
+        habitable: {
+          props: {
+            value: true,
+          },
+        },
+      }),
+    );
+  });
+
+  it('should give an InvalidPlanetDispositionException, when disposition is in valid', () => {
+    const planetOrError = Planet.create(PlanetsBuild.generate({ disposition: 'INVALID' }));
+
+    expect(planetOrError.isRight()).toBeFalsy();
+    expect(planetOrError.value).toBeInstanceOf(InvalidPlanetDispositionException);
+    expect(planetOrError).toEqual(left(new InvalidPlanetDispositionException('INVALID')));
+  });
+});

--- a/src/modules/planets/domains/Planet.ts
+++ b/src/modules/planets/domains/Planet.ts
@@ -1,0 +1,54 @@
+import { Entity } from '@shared/domain/Entity';
+import { Either, left, right } from '@shared/either';
+
+import { PlanetHabitable } from './PlanetHabitable';
+import { PlanetDisposition } from './PlanetDisposition';
+import { InvalidPlanetDispositionException } from './exceptions/InvalidPlanetDispositionException';
+import { CreateStellarDTO, Stellar } from '@modules/stellars/Stellar';
+
+export interface PlanetProps {
+  name: string;
+  telescope: string;
+  habitable: PlanetHabitable;
+  disposition: PlanetDisposition;
+  stellar: Stellar;
+  radius: number;
+  insolation: number;
+}
+
+export interface CreatePlanetDTO {
+  name: string;
+  telescope: string;
+  disposition: string;
+  stellar: Stellar;
+  radius: number;
+  insolation: number;
+}
+
+export class Planet extends Entity<PlanetProps> {
+  private constructor(props: PlanetProps) {
+    super(props);
+  }
+
+  static create(data: CreatePlanetDTO): Either<InvalidPlanetDispositionException, Planet> {
+    const dispositionOrError = PlanetDisposition.create(data.disposition);
+
+    if (dispositionOrError.isLeft()) {
+      return left(dispositionOrError.value);
+    }
+
+    const habitable = PlanetHabitable.create({
+      radius: data.radius,
+      disposition: data.disposition,
+      insolation: data.insolation,
+    });
+
+    return right(
+      new Planet({
+        ...data,
+        habitable,
+        disposition: dispositionOrError.value,
+      }),
+    );
+  }
+}

--- a/src/modules/planets/domains/PlanetDisposition.spec.ts
+++ b/src/modules/planets/domains/PlanetDisposition.spec.ts
@@ -2,7 +2,7 @@ import { left, right } from '@shared/either';
 import { InvalidPlanetDispositionException } from './exceptions/InvalidPlanetDispositionException';
 import { PlanetDisposition } from './PlanetDisposition';
 
-describe('[UNIT] - [Planets] - PlanetHabitable ValueObject', () => {
+describe('[UNIT] - [Planets] - PlanetDisposition ValueObject', () => {
   it('should be able return PlanetDisposition, when disposition is confirmed', () => {
     const planetDispositionOrError = PlanetDisposition.create('CONFIRMED');
 

--- a/src/modules/planets/domains/PlanetDisposition.spec.ts
+++ b/src/modules/planets/domains/PlanetDisposition.spec.ts
@@ -1,0 +1,29 @@
+import { left, right } from '@shared/either';
+import { InvalidPlanetDispositionException } from './exceptions/InvalidPlanetDispositionException';
+import { PlanetDisposition } from './PlanetDisposition';
+
+describe('[UNIT] - [Planets] - PlanetHabitable ValueObject', () => {
+  it('should be able return PlanetDisposition, when disposition is confirmed', () => {
+    const planetDispositionOrError = PlanetDisposition.create('CONFIRMED');
+
+    expect(planetDispositionOrError.isLeft()).toBeFalsy();
+
+    const planet = planetDispositionOrError.value;
+
+    expect(planet).toEqual({ props: { value: 'CONFIRMED' } });
+  });
+
+  it('should be able return true, when disposition is valid', () => {
+    expect(PlanetDisposition.validate('FALSE POSITIVE')).toBe(true);
+    expect(PlanetDisposition.validate('CANDIDATE')).toBe(true);
+    expect(PlanetDisposition.validate('NOT DISPOSITIONED')).toBe(true);
+    expect(PlanetDisposition.validate('CONFIRMED')).toBe(true);
+  });
+
+  it('should give an InvalidPlaneDispositionException, when disposition is invalid', () => {
+    const planetDispositionOrError = PlanetDisposition.create('INVALID');
+
+    expect(planetDispositionOrError.isRight()).toBeFalsy();
+    expect(planetDispositionOrError).toEqual(left(new InvalidPlanetDispositionException('INVALID')));
+  });
+});

--- a/src/modules/planets/domains/PlanetDisposition.ts
+++ b/src/modules/planets/domains/PlanetDisposition.ts
@@ -1,0 +1,35 @@
+import { ValueObject } from '@shared/domain/ValueObject';
+import { Either, left, right } from '@shared/either';
+import { InvalidPlanetDispositionException } from './exceptions/InvalidPlanetDispositionException';
+
+interface PlanetDispositionProps {
+  value: string;
+}
+
+export class PlanetDisposition extends ValueObject<PlanetDispositionProps> {
+  public get value(): string {
+    return this.props.value;
+  }
+
+  private constructor(props: PlanetDispositionProps) {
+    super(props);
+  }
+
+  public static create(value: string): Either<InvalidPlanetDispositionException, PlanetDisposition> {
+    if (!PlanetDisposition.validate(value)) {
+      return left(new InvalidPlanetDispositionException(value));
+    }
+
+    return right(new PlanetDisposition({ value }));
+  }
+
+  public static validate(value: string): boolean {
+    const planetDispositionRegex = /CONFIRMED|CANDIDATE|FALSE POSITIVE|NOT DISPOSITIONED/i;
+
+    if (!planetDispositionRegex.test(value)) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/modules/planets/domains/PlanetHabitable.spec.ts
+++ b/src/modules/planets/domains/PlanetHabitable.spec.ts
@@ -1,0 +1,63 @@
+import { PlanetHabitable } from './PlanetHabitable';
+
+describe('[UNIT] - [Planets] - PlanetHabitable ValueObject', () => {
+  it('should be able to save value as true, when planet is habitable', () => {
+    const planetHabitable = PlanetHabitable.create({
+      disposition: 'CONFIRMED',
+      insolation: 0.37,
+      radius: 1.5,
+    });
+
+    expect(planetHabitable.value).toBe(true);
+  });
+
+  it('should be able to return false, when planet is not confirmed', () => {
+    const planetHabitable = PlanetHabitable.create({
+      disposition: 'CANDIDATE',
+      insolation: 0.37,
+      radius: 1.5,
+    });
+
+    expect(planetHabitable.value).toBe(false);
+  });
+
+  it('should be able to return false, when insolation FLUX is less than 0.37', () => {
+    const planetHabitable = PlanetHabitable.create({
+      disposition: 'CONFIRMED',
+      insolation: 0.36,
+      radius: 1.5,
+    });
+
+    expect(planetHabitable.value).toBe(false);
+  });
+
+  it('should be able to return false, when insolation FLUX is greater than 1.11', () => {
+    const planetHabitable = PlanetHabitable.create({
+      disposition: 'CONFIRMED',
+      insolation: 1.12,
+      radius: 1.5,
+    });
+
+    expect(planetHabitable.value).toBe(false);
+  });
+
+  it('should be able to return false, when radius is greater than 1.5', () => {
+    const planetHabitable = PlanetHabitable.create({
+      disposition: 'CONFIRMED',
+      insolation: 0.37,
+      radius: 1.7,
+    });
+
+    expect(planetHabitable.value).toBe(false);
+  });
+
+  it('should be able to return false, when radius is less than 0.5', () => {
+    const planetHabitable = PlanetHabitable.create({
+      disposition: 'CONFIRMED',
+      insolation: 0.37,
+      radius: 0.4,
+    });
+
+    expect(planetHabitable.value).toBe(false);
+  });
+});

--- a/src/modules/planets/domains/PlanetHabitable.ts
+++ b/src/modules/planets/domains/PlanetHabitable.ts
@@ -1,0 +1,43 @@
+import { ValueObject } from '@shared/domain/ValueObject';
+
+interface PlanetHabitableProps {
+  value: boolean;
+}
+
+interface CreatePlanetHabitableDTO {
+  insolation: number;
+  disposition: string;
+  radius: number;
+}
+
+export class PlanetHabitable extends ValueObject<PlanetHabitableProps> {
+  get value(): boolean {
+    return this.props.value;
+  }
+
+  private constructor(props: PlanetHabitableProps) {
+    super(props);
+  }
+
+  public static create(data: CreatePlanetHabitableDTO): PlanetHabitable {
+    return new PlanetHabitable({ value: PlanetHabitable.isHabitable(data) });
+  }
+
+  public static isHabitable({ disposition, insolation, radius }: CreatePlanetHabitableDTO): boolean {
+    const dispositionRegex = /CONFIRMED/gi;
+
+    if (!dispositionRegex.test(disposition)) {
+      return false;
+    }
+
+    if (insolation < 0.37 || insolation > 1.11) {
+      return false;
+    }
+
+    if (radius < 0.5 || radius > 1.5) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/modules/planets/domains/builds/PlanetsBuild.ts
+++ b/src/modules/planets/domains/builds/PlanetsBuild.ts
@@ -1,0 +1,53 @@
+import { Stellar } from '@modules/stellars/Stellar';
+import { Planet, CreatePlanetDTO } from '../Planet';
+
+interface CreateCSVDTO {
+  data: Partial<CreatePlanetDTO>[];
+}
+
+export class PlanetsBuild {
+  static generate(data?: Partial<CreatePlanetDTO>) {
+    const planet = {
+      name: data?.name || 'Tatooine',
+      disposition: data?.disposition || 'CONFIRMED',
+      insolation: data?.insolation || 0.37,
+      radius: data?.radius || 1.5,
+      stellar:
+        data?.stellar ||
+        Stellar.create({
+          radius: 10,
+          mass: '1',
+          age: '1',
+          effective_temperature: '1',
+          smet: '1',
+        }),
+      telescope: data?.telescope || 'Kepler',
+    };
+
+    return planet;
+  }
+
+  static create(data?: Partial<CreatePlanetDTO>) {
+    const planet = this.generate(data);
+
+    return Planet.create(planet).value as Planet;
+  }
+
+  static createInvalid(data?: Partial<CreatePlanetDTO>) {
+    const planet = this.generate(data);
+
+    return Planet.create(planet);
+  }
+
+  static createCSV({ data }: CreateCSVDTO) {
+    const header = ['kepler_name,koi_disposition,koi_insol,koi_prad,koi_srad,koi_steff,koi_sage,koi_smet,koi_smass'];
+
+    const rows = data.map(({ name, disposition, insolation, radius, stellar: { props: stellar } }) => {
+      return `${name},${disposition},${insolation},${radius},${stellar.radius},${stellar.effective_temperature},${stellar.age},${stellar.smet},${stellar.mass}`;
+    });
+
+    const csv = header.concat(rows).join('\n');
+
+    return csv;
+  }
+}

--- a/src/modules/planets/domains/exceptions/InvalidPlanetDispositionException.ts
+++ b/src/modules/planets/domains/exceptions/InvalidPlanetDispositionException.ts
@@ -1,0 +1,7 @@
+import { BaseException } from '@shared/domain/BaseException';
+
+export class InvalidPlanetDispositionException extends Error implements BaseException {
+  constructor(disposition: string) {
+    super(`${disposition} is not a valid planet disposition`);
+  }
+}

--- a/src/modules/stellars/Stellar.spec.ts
+++ b/src/modules/stellars/Stellar.spec.ts
@@ -1,0 +1,20 @@
+import { Stellar } from './Stellar';
+
+describe('[UNIT] - [Stellars] - Stellar entity', () => {
+  it('should be able to return an Stellar, when fields are valid', () => {
+    const data = {
+      mass: '5853',
+      radius: 5853,
+      effective_temperature: '5853',
+      smet: 'smet-in-stellar-create-test',
+      age: '5',
+    };
+
+    const stellar = Stellar.create(data);
+
+    expect(stellar).toBeInstanceOf(Stellar);
+
+    expect(stellar.id).toBeDefined();
+    expect(stellar.props).toEqual(expect.objectContaining(data));
+  });
+});

--- a/src/modules/stellars/Stellar.ts
+++ b/src/modules/stellars/Stellar.ts
@@ -1,0 +1,34 @@
+import { Entity } from '@shared/domain/Entity';
+import { UniqueIdentifier } from '@shared/domain/UniqueIdentifier';
+
+interface StellarProps {
+  mass: string;
+  effective_temperature: string;
+  smet: string;
+  radius: number;
+  age: string;
+}
+
+export interface CreateStellarDTO {
+  mass: string;
+  effective_temperature: string;
+  smet: string;
+  radius: number;
+  age: string;
+}
+
+export class Stellar extends Entity<StellarProps> {
+  private constructor(props: StellarProps) {
+    super(props);
+  }
+
+  static create(data: CreateStellarDTO): Stellar {
+    return new Stellar({
+      mass: data.mass,
+      effective_temperature: data.effective_temperature,
+      smet: data.smet,
+      radius: data.radius,
+      age: data.age,
+    });
+  }
+}

--- a/src/shared/domain/Entity.ts
+++ b/src/shared/domain/Entity.ts
@@ -5,7 +5,7 @@ const isEntity = (other: any): other is Entity<any> => {
 };
 
 export abstract class Entity<T> {
-  constructor(readonly props: T, protected readonly id?: UniqueIdentifier) {
+  constructor(readonly props: T, readonly id?: UniqueIdentifier) {
     this.id = id || new UniqueIdentifier();
     this.props = props;
   }

--- a/src/shared/domain/Identifier.ts
+++ b/src/shared/domain/Identifier.ts
@@ -19,4 +19,3 @@ export class Identifier<T> {
     return this.value;
   }
 }
-

--- a/src/shared/domain/UniqueIdentifier.ts
+++ b/src/shared/domain/UniqueIdentifier.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid';
 import { Identifier } from './Identifier';
 
 export class UniqueIdentifier extends Identifier<string> {
-  constructor(id?: Identifier) {
+  constructor(id?: string) {
     super(id || uuid());
   }
 }

--- a/src/shared/domain/ValueObject.ts
+++ b/src/shared/domain/ValueObject.ts
@@ -5,11 +5,11 @@ interface ValueObjectProps {
 }
 
 export abstract class ValueObject<T extends ValueObjectProps> {
-  constructor(protected props: T) {
+  constructor(readonly props: T) {
     this.props = Object.freeze(props);
   }
 
-  equals(other: ValueObject<T>): boolean {
+  public equals(other: ValueObject<T>): boolean {
     if (other === null || other === undefined) {
       return false;
     }


### PR DESCRIPTION
# Description :smile_cat: 
#### [FEAT]

>**src/modules/stellar/domain**
  - [x] added Stellar entity.

>**src/modules/planets/domain**
  - [x] added Planet entity with factory method
  - [x] added PlanetHabitable ValueObject to determine if planet can be habitable or not.
  - [x] added PlanetDisposition ValueObject with some validations of fields.  

#### [FIX]

>**shared/domain/UniqueIdentifier**
  - [x] Fixing type of id in constructor, from Identifier to string.

>**shared/domain/ValueObject & shared/domain/Entity**
  - [x] Change protect to readonly in props inside of constructor.

## Type of change

- [ ] Config (non-breaking change which adds or fixes configuration files)
- [x] Test (non-breaking change which adds or fixes existing tests)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

> Planet
  - [x] check if planet can create with valid fields
  - [x] check if return an InvalidPlanetDispositionException, when disposition is not valid.

> PlanetDisposition
  - [x] check if is return correct data from right(Either), when send one correct field('CONFIRMED').
  - [x] check if all correct fields are validate correctly..
  - [x] check if return an InvalidPlanetDispositionException, when send invalid fields 

> PlanetHabitable
  - [x] check if return true, when planet can be habitable.
  - [x] check if return false, when send data that determine the planet can't be 

> Stellar
  - [x] check if can be created with valid fields

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules